### PR TITLE
Normalize permissions after unpacking archives

### DIFF
--- a/drupy/objects.py
+++ b/drupy/objects.py
@@ -352,7 +352,7 @@ class TarballExtract(Applier):
             return target + "/" + name
 
         unpack(self.path, target, progress_filter=extract_filter)
-        utils.normalize_permissions(self.path)
+        utils.normalize_permissions(target)
 
     def is_valid(self):
         if self.type == "tarball":

--- a/drupy/objects.py
+++ b/drupy/objects.py
@@ -13,7 +13,7 @@ from glob import glob
 import setuptools.archive_util
 
 
-def addDefaults(config, defaults):
+def add_defaults(config, defaults):
     queue = [(config, defaults)]
 
     while len(queue) > 0:
@@ -48,29 +48,31 @@ class Config:
     def __init__(self, runner, path):
         self.runner = runner
         self.path = path
-        self.config = self.readConfig()
+        self.config = self.read_config()
 
-    def readConfig(self):
+    def read_config(self):
         o = self.runner.options
         files = [(None, self.path)]
         data = collections.OrderedDict()
         while len(files) > 0:
             relTo, path = files.pop(0)
             path = (
-                self.runner.getDownloader({"url": path}).download(relTo, o.downloadDir).localpath()
+                self.runner.get_downloader({"url": path})
+                .download(relTo, o.download_dir)
+                .localpath()
             )
-            new_data = self.readFile(path)
+            new_data = self.read_file(path)
             if "includes" in new_data:
                 includes = new_data["includes"]
                 del new_data["includes"]
                 relTo = os.path.dirname(path)
                 for inc in includes:
                     files.append((relTo, inc))
-            addDefaults(data, new_data)
-        addDefaults(data, self.defaults)
+            add_defaults(data, new_data)
+        add_defaults(data, self.defaults)
         return data
 
-    def readFile(self, path):
+    def read_file(self, path):
         parser = get_parser(path)
         with open(path) as configfile:
             try:
@@ -109,7 +111,7 @@ class Tree(Config):
     @property
     def installed_projects(self):
         o = self.runner.options
-        return frozenset(os.listdir(os.path.join(o.installDir, o.projectsDir)))
+        return frozenset(os.listdir(os.path.join(o.install_dir, o.projects_dir)))
 
     @property
     def used_projects(self):
@@ -172,7 +174,7 @@ class TypedFactory:
         for t in self.types:
             try:
                 obj = t(self.runner, config)
-                if obj.isValid():
+                if obj.is_valid():
                     return obj
             except ValueError as e:
                 """Implementations can err out of non-applicable configs."""
@@ -196,11 +198,11 @@ class Downloader:
     def localpath(self):
         return self.url
 
-    def isValid(self):
+    def is_valid(self):
         return True
 
-    def convertToMake(self, pfx, patchShortHand=False):
-        if patchShortHand:
+    def convert_to_make(self, pfx, patch_short_hand=False):
+        if patch_short_hand:
             print("%s = %s" % (pfx, self.url))
         else:
             print("%s[type] = file" % (pfx))
@@ -209,17 +211,17 @@ class Downloader:
 
 class ScmNoopDownloader(Downloader):
     def __init__(self, runner, config):
-        hasScmType = "type" in config and config["type"] in ["git"]
-        hasRevisionOrBranch = "revision" in config or "branch" in config
-        if not hasScmType and not hasRevisionOrBranch:
+        has_scm_type = "type" in config and config["type"] in ["git"]
+        has_revision_or_branch = "revision" in config or "branch" in config
+        if not has_scm_type and not has_revision_or_branch:
             raise ValueError("This is not a SCM ressource")
         Downloader.__init__(self, runner, config)
-        self.scmType = "git"
+        self.scm_type = "git"
         self.branch = config["branch"] if "branch" in config else False
         self.revision = config["revision"] if "revision" in config else False
 
-    def convertToMake(self, pfx, patchShortHand=False):
-        print(pfx + "[type] = " + self.scmType)
+    def convert_to_make(self, pfx, patch_short_hand=False):
+        print(pfx + "[type] = " + self.scm_type)
         print(pfx + "[url] = " + self.url)
         if self.branch:
             print(pfx + "[branch] = " + self.branch)
@@ -238,7 +240,7 @@ class LocalDownloader(Downloader):
     def localpath(self):
         return self.path
 
-    def isValid(self):
+    def is_valid(self):
         return not self.scheme
 
 
@@ -250,7 +252,7 @@ class UrllibDownloader(Downloader):
         filename = self.url.replace("/", "-").replace(":", "-")
         self.path = os.path.join(store, filename)
         if os.path.exists(self.path):
-            if not self.hash or self.getHash() == self.hash:
+            if not self.hash or self.get_hash() == self.hash:
                 return
             else:
                 os.unlink(self.path)
@@ -264,20 +266,20 @@ class UrllibDownloader(Downloader):
         with open(self.path, "wb") as target:
             target.write(f.read())
         if self.hash:
-            actual_hash = self.getHash()
+            actual_hash = self.get_hash()
             if self.hash != actual_hash:
                 msg = "Hash of file downloaded from {} wrong: {} instead of {}"
                 raise Exception(msg.format(self.url, actual_hash, self.hash))
         return self
 
-    def getHash(self):
+    def get_hash(self):
         with open(self.path, "rb") as f:
             return hashlib.sha1(f.read()).hexdigest()
 
     def localpath(self):
         return self.path
 
-    def isValid(self):
+    def is_valid(self):
         schemes = ["http", "https", "ftp"]
         return self.scheme in schemes and not self.url.endswith(".git")
 
@@ -288,30 +290,30 @@ class Ressource:
         self.config = deepcopy(config)
         if type(self.config) is str:
             self.config = {"url": config}
-        addDefaults(self.config, dict(devel=None))
+        add_defaults(self.config, dict(devel=None))
 
     def download(self):
         o = self.runner.options
-        downloader = self.runner.getDownloader(self.config)
-        downloader.download(o.sourceDir, o.downloadDir)
+        downloader = self.runner.get_downloader(self.config)
+        downloader.download(o.source_dir, o.download_dir)
         self.config["localpath"] = downloader.localpath()
 
-    def applyTo(self, target):
+    def apply_to(self, target):
         devel = self.config["devel"]
         if devel is not None and devel != self.runner.options.devel:
             "Don't apply ressources that are production or devel only"
             return
-        applier = self.runner.getApplier(self.config)
-        applier.applyTo(target)
+        applier = self.runner.get_applier(self.config)
+        applier.apply_to(target)
 
-    def convertToMake(self, pfx, patchShortHand=False):
+    def convert_to_make(self, pfx, patch_short_hand=False):
         if "purpose" in self.config:
             comment = "; " + self.config["purpose"]
             if "link" in self.config:
                 comment += " - " + self.config["link"]
             print(comment)
-        downloader = self.runner.getDownloader(self.config)
-        downloader.convertToMake(pfx, patchShortHand)
+        downloader = self.runner.get_downloader(self.config)
+        downloader.convert_to_make(pfx, patch_short_hand)
 
 
 class Applier:
@@ -325,21 +327,21 @@ class Applier:
 class TarballExtract(Applier):
     exts = [".tar.gz", ".tgz", ".tar.bz2", "tbz2", ".tar.xz", ".tar", ".zip"]
 
-    def applyTo(self, target):
+    def apply_to(self, target):
         unpack = setuptools.archive_util.unpack_archive
 
         # Dry run to find longest prefix.
         paths = []
 
-        def recordPaths(name, destination):
+        def record_paths(name, destination):
             paths.append(name)
             return False
 
-        unpack(self.path, target, progress_filter=recordPaths)
+        unpack(self.path, target, progress_filter=record_paths)
         prefix = len(os.path.commonprefix(paths))
 
         # Actuall unpacking.
-        def extractFilter(name, destination):
+        def extract_filter(name, destination):
             if len(name) <= prefix:
                 return False
             name = name[prefix:]
@@ -347,9 +349,9 @@ class TarballExtract(Applier):
                 name = name[1:]
             return target + "/" + name
 
-        unpack(self.path, target, progress_filter=extractFilter)
+        unpack(self.path, target, progress_filter=extract_filter)
 
-    def isValid(self):
+    def is_valid(self):
         if self.type == "tarball":
             return True
         for ext in self.exts:
@@ -359,11 +361,11 @@ class TarballExtract(Applier):
 
 
 class PatchApplier(Applier):
-    def applyTo(self, target):
+    def apply_to(self, target):
         cmd = "patch --no-backup-if-mismatch -p1 -d {} < {}"
         self.runner.command(cmd.format(target, self.path), shell=True)
 
-    def isValid(self):
+    def is_valid(self):
         p = self.path
         return p.endswith(".patch") or p.endswith(".diff") or self.type == "patch"
 
@@ -371,13 +373,13 @@ class PatchApplier(Applier):
 class CopyFileApplier(Applier):
     def __init__(self, runner, config):
         Applier.__init__(self, runner, config)
-        addDefaults(config, dict(filepath=os.path.basename(config["url"])))
+        add_defaults(config, dict(filepath=os.path.basename(config["url"])))
         self.filepath = config["filepath"]
 
-    def applyTo(self, target):
+    def apply_to(self, target):
         shutil.copyfile(self.path, os.path.join(target, self.filepath))
 
-    def isValid(self):
+    def is_valid(self):
         return os.path.isfile(self.path)
 
 
@@ -387,7 +389,7 @@ class GitRepoApplier(Applier):
         self.url = config["url"]
         self.shallow = config.get("shallow", True)
 
-    def applyTo(self, target):
+    def apply_to(self, target):
         call = ["git", "clone", self.url]
 
         if "branch" in self.config:
@@ -406,22 +408,22 @@ class GitRepoApplier(Applier):
             self.runner.command(["git", "checkout", self.config["revision"]])
             os.chdir(wd)
 
-    def isValid(self):
+    def is_valid(self):
         return self.type == "git" or "branch" in self.config or "revision" in self.config
 
 
 class DirectoryApplier(Applier):
-    def applyTo(self, target):
-        self.runner.ensureDir(target)
+    def apply_to(self, target):
+        self.runner.ensure_dir(target)
         self.runner.command(["rsync", "-rlt", self.path + "/", target + "/"])
 
-    def isValid(self):
+    def is_valid(self):
         return os.path.isdir(self.path)
 
 
 class Project:
     def __init__(self, runner, config):
-        addDefaults(
+        add_defaults(
             config,
             {
                 "type": None,
@@ -439,29 +441,29 @@ class Project:
         self.type = config["type"]
         self.protected = config["protected"]
 
-    def isValid(self):
+    def is_valid(self):
         return True
 
     def build(self, target):
-        self.runner.ensureDir(target)
+        self.runner.ensure_dir(target)
         for config in self.pipeline:
             ressource = Ressource(self.runner, config)
             ressource.download()
-            ressource.applyTo(target)
+            ressource.apply_to(target)
 
     def hashDict(self, the_dict):
         jsonDump = json.dumps(the_dict, sort_keys=True)
         return hashlib.sha1(jsonDump.encode("utf-8")).hexdigest()
 
-    def convertToMake(self):
+    def convert_to_make(self):
         parts = self.dirname.split("-", 2)
         pkey = "projects[%s]" % parts[0]
         pipeline = copy(self.pipeline)
         first = Ressource(self.runner, pipeline.pop(0))
-        first.convertToMake(pkey + "[download]")
+        first.convert_to_make(pkey + "[download]")
         for config in pipeline:
             ressource = Ressource(self.runner, config)
-            ressource.convertToMake(pkey + "[patch][]", True)
+            ressource.convert_to_make(pkey + "[patch][]", True)
         print()
 
 
@@ -518,15 +520,15 @@ class DrupalOrgProject(Project):
             return match.group(1), match.group(2), match.group(3), extras
         raise ValueError('Not a valid package string: "{}"'.format(name))
 
-    def isValid(self):
+    def is_valid(self):
         return self.type == "drupal.org" and len(self.pipeline) >= 1
 
-    def convertToMake(self):
+    def convert_to_make(self):
         pkey = "projects[%s]" % self.project
         print("%s[version] = %s" % (pkey, self.version))
         pipeline = copy(self.pipeline)
         pipeline.pop(0)
         for config in pipeline:
             ressource = Ressource(self.runner, config)
-            ressource.convertToMake(pkey + "[patch][]", True)
+            ressource.convert_to_make(pkey + "[patch][]", True)
         print()

--- a/drupy/objects.py
+++ b/drupy/objects.py
@@ -12,6 +12,8 @@ from glob import glob
 
 import setuptools.archive_util
 
+from drupy import utils
+
 
 def add_defaults(config, defaults):
     queue = [(config, defaults)]
@@ -350,6 +352,7 @@ class TarballExtract(Applier):
             return target + "/" + name
 
         unpack(self.path, target, progress_filter=extract_filter)
+        utils.normalize_permissions(self.path)
 
     def is_valid(self):
         if self.type == "tarball":

--- a/drupy/runner.py
+++ b/drupy/runner.py
@@ -133,7 +133,7 @@ class CommandParser(ArgumentParser):
         )
         build_group.add_argument(
             "--source-dir",
-            dest="sourceDir",
+            dest="source_dir",
             type=str,
             help="Directory with the site configuration (see README for the config format). (default: "
             + defaults["source-dir"]
@@ -151,14 +151,14 @@ class CommandParser(ArgumentParser):
         )
         build_group.add_argument(
             "--downloads-dir",
-            dest="downloadDir",
+            dest="download_dir",
             type=str,
             help="Directory where downloaded files will be stored. (default: [install-dir]/downloads)",
             default=None,
         )
         build_group.add_argument(
             "--overrides-dir",
-            dest="overridesDir",
+            dest="overrides_dir",
             type=str,
             help="Base-dir used for project overrides. (default: "
             + defaults["overrides-dir"]
@@ -175,8 +175,8 @@ class CommandParser(ArgumentParser):
 
     def parse_args(self):
         options = ArgumentParser.parse_args(self)
-        if not options.downloadDir:
-            options.downloadDir = os.path.join(options.install_dir, "downloads")
+        if not options.download_dir:
+            options.download_dir = os.path.join(options.install_dir, "downloads")
 
         # parse overrides arguments.
         mapping = {}

--- a/drupy/runner.py
+++ b/drupy/runner.py
@@ -142,7 +142,7 @@ class CommandParser(ArgumentParser):
         )
         build_group.add_argument(
             "--install-dir",
-            dest="installDir",
+            dest="install_dir",
             type=str,
             help="Directory where the project will be built. (default: "
             + defaults["install-dir"]
@@ -176,7 +176,7 @@ class CommandParser(ArgumentParser):
     def parse_args(self):
         options = ArgumentParser.parse_args(self)
         if not options.downloadDir:
-            options.downloadDir = os.path.join(options.installDir, "downloads")
+            options.downloadDir = os.path.join(options.install_dir, "downloads")
 
         # parse overrides arguments.
         mapping = {}
@@ -230,21 +230,21 @@ class Runner:
             ],
         )
 
-    def getDownloader(self, config):
+    def get_downloader(self, config):
         return self.downloaderFactory.produce(config)
 
-    def getApplier(self, config):
+    def get_applier(self, config):
         return self.applierFactory.produce(config)
 
     def getProject(self, config):
         return self.projectFactory.produce(config)
 
-    def ensureDir(self, d):
+    def ensure_dir(self, d):
         if not os.path.exists(d):
             os.makedirs(d)
 
     def rsyncDirs(self, source, target, excludes=[], onlyNonExisting=False):
-        self.ensureDir(target)
+        self.ensure_dir(target)
         cmd = ["rsync", "-rlt", "--delete", "--progress", source + "/", target + "/"]
         if onlyNonExisting:
             cmd.append("--ignore-existing")
@@ -253,7 +253,7 @@ class Runner:
 
     def projectSymlinks(self, path, elements, depth=0):
         dirqueue = [(path, depth, elements)]
-        projects = self.options.projectsDir
+        projects = self.options.projects_dir
         while len(dirqueue) > 0:
             path, depth, element = dirqueue.pop(0)
             if type(element) == str:
@@ -289,11 +289,11 @@ class Runner:
 
     def parseConfig(self):
         o = self.options
-        path = glob(o.sourceDir + "/project.*")[0]
+        path = glob(o.source_dir + "/project.*")[0]
         self.config = objects.Tree(self, path)
-        o.documentRoot = self.config.config["documentRoot"]
-        o.coreConfig = self.config.config["core"]
-        o.projectsDir = self.config.config["projectsDir"]
+        o.document_root = self.config.config["documentRoot"]
+        o.core_config = self.config.config["core"]
+        o.projects_dir = self.config.config["projectsDir"]
 
     def run(self):
         self.parseConfig()
@@ -327,7 +327,7 @@ class Runner:
         if config["core"]["project"].startswith("drupal-"):
             print("core = 7.x")
         for project in self.config.projects.values():
-            project.convertToMake()
+            project.convert_to_make()
 
     def runReport(self):
         """
@@ -369,7 +369,7 @@ class Runner:
         if obsolete_projects:
             print("Deleting obsolete projects …")
             for p in sorted(obsolete_projects):
-                shutil.rmtree(os.path.join(o.installDir, o.projectsDir, p))
+                shutil.rmtree(os.path.join(o.install_dir, o.projects_dir, p))
                 print("\t{} deleted.".format(p))
 
 

--- a/drupy/targets.py
+++ b/drupy/targets.py
@@ -12,8 +12,8 @@ class DirsTarget(resolver.Target):
 
     def build(self):
         o = self.options
-        self.runner.ensureDir(o.downloadDir)
-        self.runner.ensureDir(os.path.join(o.installDir, o.projectsDir))
+        self.runner.ensure_dir(o.download_dir)
+        self.runner.ensure_dir(os.path.join(o.install_dir, o.projects_dir))
 
 
 class BuildProjectTarget(resolver.Target):
@@ -22,7 +22,7 @@ class BuildProjectTarget(resolver.Target):
         o = self.runner.options
         self.name = project
         self.project = self.runner.config.projects[project]
-        self.target = os.path.join(o.installDir, o.projectsDir, project)
+        self.target = os.path.join(o.install_dir, o.projects_dir, project)
 
     def dependencies(self):
         return [DirsTarget(self.runner)]
@@ -74,7 +74,7 @@ class DBInstallTarget(resolver.SiteTarget):
     def already_built(self):
         os.path.exists(
             os.path.join(
-                self.options.installDir,
+                self.options.install_dir,
                 self.options.documentRoot,
                 "sites",
                 self.site,
@@ -98,7 +98,7 @@ class DBInstallTarget(resolver.SiteTarget):
 
         cmd = ["si", "-y", "--sites-subdir=" + self.site, "--db-url=" + db_url]
         cmd += [
-            "--root=" + os.path.join(o.installDir, o.documentRoot),
+            "--root=" + os.path.join(o.install_dir, o.document_root),
             "--account-mail=" + config["account-mail"],
             "--site-name=" + config["site-name"],
             "--site-mail=" + config["site-mail"],
@@ -123,7 +123,7 @@ class ProfileInstallTarget(resolver.Target):
         super().__init__(runner)
         o = self.options
         self.profile = profile
-        self.target = os.path.join(o.installDir, o.documentRoot, "profiles")
+        self.target = os.path.join(o.install_dir, o.document_root, "profiles")
         self.source = self.runner.config.config["core"]["profiles"][profile]
         self.project = self.source
         if "/" in self.project:
@@ -181,7 +181,7 @@ class SiteInstallTarget(resolver.SiteTarget):
     def __init__(self, runner, site):
         resolver.SiteTarget.__init__(self, runner, site)
         o = self.options
-        self.target = os.path.join(o.installDir, o.documentRoot, "sites", self.site)
+        self.target = os.path.join(o.install_dir, o.document_root, "sites", self.site)
         self.links = self.runner.config.sites[self.site].config["links"]
 
     def dependencies(self):
@@ -198,7 +198,7 @@ class SiteInstallTarget(resolver.SiteTarget):
         return targets
 
     def build(self):
-        self.runner.ensureDir(self.target)
+        self.runner.ensure_dir(self.target)
         self.runner.projectSymlinks(self.target, self.links, 2)
 
 
@@ -215,8 +215,8 @@ class CoreInstallTarget(resolver.Target):
     def __init__(self, runner):
         resolver.Target.__init__(self, runner)
         o = self.options
-        self.source = os.path.join(o.installDir, o.projectsDir, o.coreConfig["project"])
-        self.target = os.path.join(o.installDir, o.documentRoot)
+        self.source = os.path.join(o.install_dir, o.projects_dir, o.core_config["project"])
+        self.target = os.path.join(o.install_dir, o.document_root)
         self.src_hash = os.path.join(self.source, ".dbuild-hash")
         self.tgt_hash = os.path.join(self.target, ".dbuild-hash")
 
@@ -233,7 +233,7 @@ class CoreInstallTarget(resolver.Target):
 
     def build(self):
         rsync = self.runner.rsyncDirs
-        protected = self.options.coreConfig["protected"]
+        protected = self.options.core_config["protected"]
         # Sync core but keep sites and profile symlinks.
         profiles = self.runner.config.config["core"]["profiles"]
         excludes = ["profiles/" + x for x in profiles]

--- a/drupy/utils.py
+++ b/drupy/utils.py
@@ -1,0 +1,25 @@
+"""Utility functions."""
+
+import os
+import os.path
+
+
+def get_umask():
+    """Read the umask currently set for this process."""
+    # The umask can’t be read without writing it so set it and reset it immediately.
+    umask = os.umask(0)
+    os.umask(umask)
+    return umask
+
+
+def normalize_permissions(path):
+    """Recursively set the permissions on files and directories based on the current umask."""
+    umask = get_umask()
+    dir_perm = 0o777 & ~umask
+    file_perm = 0o666 & ~umask
+
+    for root, dirs, files in os.walk(path):
+        for dir_ in dirs:
+            os.chmod(os.path.join(root, dir_), dir_perm)
+        for file in files:
+            os.chmod(os.path.join(root, file), file_perm)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,9 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 astroid==2.5.6
     # via pylint
-atomicwrites==1.2.1
-    # via pytest
-attrs==18.2.0
+attrs==21.2.0
     # via pytest
 black==21.5b2
     # via -r requirements-dev.in
@@ -27,7 +25,7 @@ click==8.0.1
     #   black
     #   pip-tools
     #   safety
-coverage==4.5.2
+coverage==5.5
     # via pytest-cov
 distlib==0.3.2
     # via virtualenv
@@ -39,6 +37,8 @@ identify==2.2.10
     # via pre-commit
 idna==2.10
     # via requests
+iniconfig==1.1.1
+    # via pytest
 isort==5.8.0
     # via
     #   -r requirements-dev.in
@@ -56,6 +56,7 @@ nodeenv==1.6.0
 packaging==20.9
     # via
     #   dparse
+    #   pytest
     #   safety
 pathspec==0.8.1
     # via black
@@ -63,11 +64,11 @@ pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements-dev.in
-pluggy==0.8.0
+pluggy==0.13.1
     # via pytest
 pre-commit==2.13.0
     # via -r requirements-dev.in
-py==1.7.0
+py==1.10.0
     # via pytest
 pycodestyle==2.7.0
     # via -r requirements-dev.in
@@ -77,9 +78,9 @@ pylint==2.8.3
     # via -r requirements-dev.in
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.12.1
     # via -r requirements-dev.in
-pytest==4.1.0
+pytest==6.2.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -91,15 +92,14 @@ regex==2021.4.4
     # via black
 requests==2.25.1
     # via safety
-ruamel.yaml==0.15.85
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.17.8
     # via -r requirements.in
 safety==1.10.3
     # via -r requirements-dev.in
-six==1.12.0
-    # via
-    #   more-itertools
-    #   pytest
-    #   virtualenv
+six==1.16.0
+    # via virtualenv
 snowballstemmer==2.1.0
     # via pydocstyle
 toml==0.10.2
@@ -109,6 +109,8 @@ toml==0.10.2
     #   pep517
     #   pre-commit
     #   pylint
+    #   pytest
+    #   pytest-cov
 urllib3==1.26.5
     # via requests
 virtualenv==20.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@
 #
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
-ruamel.yaml==0.17.7
+ruamel.yaml==0.17.8
     # via -r requirements.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Fixtures for the tests."""
+
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(name="temp_dir")
+def fixture_temp_dir():
+    """Create a temporary directory and delete it after the test has run."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)

--- a/tests/objects_test.py
+++ b/tests/objects_test.py
@@ -52,14 +52,11 @@ class DrupalOrgProjectTest(TestCase):
         assert not p.is_valid()
 
 
-class TarballExtractTest(TestCase):
-    def setup_method(self, test_method):
-        self.testdir = mkdtemp()
+class TarballExtractTest:
+    """Test extracting a tarball."""
 
-    def teardown_method(self, test_method):
-        shutil.rmtree(self.testdir)
-
-    def test_libraries(self):
+    @staticmethod
+    def test_libraries(temp_dir):
         """Test whether the top-level directory is properly stripped."""
 
         class Fakerunner:
@@ -71,12 +68,13 @@ class TarballExtractTest(TestCase):
             config=dict(url="https://ftp.drupal.org/files/projects/libraries-7.x-2.3.tar.gz"),
         )
         ex = TarballExtract(
-            Fakerunner, config=dict(localpath=dl.download("", self.testdir).localpath())
+            Fakerunner, config=dict(localpath=dl.download("", temp_dir).localpath())
         )
-        ex.apply_to(self.testdir + "/libraries")
-        os.path.exists(self.testdir + "/libraries/libraries.module")
+        ex.apply_to(temp_dir + "/libraries")
+        assert os.path.exists(temp_dir + "/libraries/libraries.module")
 
-    def test_highcharts(self):
+    @staticmethod
+    def test_highcharts(temp_dir):
         """Highcharts is a zip-file without any directories to strip."""
 
         class Fakerunner:
@@ -87,7 +85,7 @@ class TarballExtractTest(TestCase):
             Fakerunner, config=dict(url="http://code.highcharts.com/zips/Highcharts-4.2.7.zip")
         )
         ex = TarballExtract(
-            Fakerunner, config=dict(localpath=dl.download("", self.testdir).localpath())
+            Fakerunner, config=dict(localpath=dl.download("", temp_dir).localpath())
         )
-        ex.apply_to(self.testdir + "/highcharts")
-        os.path.exists(self.testdir + "/highcharts/js/highcharts.js")
+        ex.apply_to(temp_dir + "/highcharts")
+        os.path.exists(temp_dir + "/highcharts/js/highcharts.js")

--- a/tests/objects_test.py
+++ b/tests/objects_test.py
@@ -34,7 +34,7 @@ class DrupalOrgProjectTest(TestCase):
     def test_is_valid(self):
         # Valid package spec without declaring type.
         p = DrupalOrgProject(None, dict(dirname="campaignion-7.x-1.0"))
-        assert p.isValid()
+        assert p.is_valid()
 
         # Invalid package spec but declaring type.
         p = DrupalOrgProject(
@@ -45,11 +45,11 @@ class DrupalOrgProjectTest(TestCase):
                 type="drupal.org",
             ),
         )
-        assert p.isValid()
+        assert p.is_valid()
 
         # Invalid package spec without declaring type.
         p = DrupalOrgProject(None, dict(dirname="testitt"))
-        assert not p.isValid()
+        assert not p.is_valid()
 
 
 class TarballExtractTest(TestCase):
@@ -73,7 +73,7 @@ class TarballExtractTest(TestCase):
         ex = TarballExtract(
             Fakerunner, config=dict(localpath=dl.download("", self.testdir).localpath())
         )
-        ex.applyTo(self.testdir + "/libraries")
+        ex.apply_to(self.testdir + "/libraries")
         os.path.exists(self.testdir + "/libraries/libraries.module")
 
     def test_highcharts(self):
@@ -89,5 +89,5 @@ class TarballExtractTest(TestCase):
         ex = TarballExtract(
             Fakerunner, config=dict(localpath=dl.download("", self.testdir).localpath())
         )
-        ex.applyTo(self.testdir + "/highcharts")
+        ex.apply_to(self.testdir + "/highcharts")
         os.path.exists(self.testdir + "/highcharts/js/highcharts.js")

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,23 @@
+"""Tests for the utility functions."""
+
+import os
+import pathlib
+
+from drupy import utils
+
+
+def test_normalize_permissions(temp_dir):
+    """Test normalizing the permissions of a folder."""
+    original_chmod = os.umask(0o0)
+    root = pathlib.Path(temp_dir)
+    root.joinpath("dir", "sub").mkdir(mode=0o700, parents=True)
+    root.joinpath("file").touch(mode=0o600)
+    root.joinpath("dir", "sub", "file").touch(mode=0o666)
+
+    os.umask(0o22)
+    utils.normalize_permissions(temp_dir)
+    os.umask(original_chmod)
+    assert root.joinpath("dir").stat().st_mode & 0o777 == 0o755
+    assert root.joinpath("dir", "sub").stat().st_mode & 0o777 == 0o755
+    assert root.joinpath("file").stat().st_mode & 0o777 == 0o644
+    assert root.joinpath("dir", "sub", "file").stat().st_mode & 0o777 == 0o644


### PR DESCRIPTION
Closes #14 

This resets the file permissions according to the unmask after unpacking an archive. Unpacking archives preserves the file permissions set within the archive by default. There is no easy way to deactivate this so resetting the permission seem the way to work around this.